### PR TITLE
Allow horizontal scrolling of Schedule page on small viewports (e.g. mobile)

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -4,7 +4,7 @@
   </div>
   <div id="post-info">
     <div id="cover-photo-container">
-      <img id="cover-photo" src="{{ site.baseurl }}/images/{{ page.cover }}" style="max-width:730px">
+      <img id="cover-photo" src="{{ site.baseurl }}/images/{{ page.cover }}">
     </div>
     <div id="info-container">
       <h1 id="title">{{ page.title }}</h1>

--- a/css/main.css
+++ b/css/main.css
@@ -127,6 +127,10 @@ a:hover {
   display: block;
 }
 
+img#cover-photo {
+  max-width: 730px;
+}
+
 #info-container {
   margin-top: 3em;
 }

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1,6 +1,10 @@
 @media (max-width:1309px) {
-  #cover-photo {
+  img#cover-photo {
     max-width: 95%;
+  }
+
+  .content {
+    overflow-x: auto;
   }
 
   .header {
@@ -56,6 +60,10 @@
 
   #cover-photo-container {
     text-align: center;
+  }
+  
+  img#cover-photo {
+    max-width: 100%;
   }
 
   #title {


### PR DESCRIPTION
Schedule page currently does not scroll horizontally, and clips content (at least on iOS), so it's hard to see the readings:

![output](https://cloud.githubusercontent.com/assets/27594/23144473/dd9f218c-f795-11e6-9dd4-49422f092a30.gif)

This edit makes the schedule page and other pages that horizontally overflow to scroll. 

![output-new](https://cloud.githubusercontent.com/assets/27594/23144470/d9b497aa-f795-11e6-8ea0-0753b0092d6c.gif)

Currently, the image in the header overflows past the page width in smaller browsers, and with horizontal overflow on, there would be a lot of extra horizontal space. To make other pages not have extraneous scrolling, the image width was changed to accommodate (fixed max-width on wider viewports, 95% or 100% width of container in smaller viewports to prevent overflow.)